### PR TITLE
[chore] add Mosquitto deployment template and documentation: COR-3707

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO monk-mosquitto
+LOAD mosquitto.yml 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,101 @@
-# monk-mosquitto
+# Mosquitto & Monk
+
+This repository contains Monk.io template to deploy Mosquitto MQTT Broker either locally or on cloud of your choice (AWS, GCP, Azure, Digital Ocean).
+
+## Prerequisites
+
+- [Install Monk](https://docs.monk.io/docs/get-monk)
+- [Register and Login Monk](https://docs.monk.io/docs/acc-and-auth)
+- [Add Cloud Provider](https://docs.monk.io/docs/cloud-provider)
+- [Add Instance](https://docs.monk.io/docs/multi-cloud)
+
+## Make sure monkd is running
+
+```bash
+foo@bar:~$ monk status
+daemon: ready
+auth: logged in
+not connected to cluster
+```
+
+## Clone Repository
+
+```bash
+git clone git@github.com:monk-io/monk-mosquitto.git
+```
+
+## Load Template
+
+```bash
+cd monk-mosquitto
+monk load MANIFEST
+```
+
+```bash
+foo@bar:~$ monk list monk-mosquitto
+✔ Got the list
+Type      Template                Repository  Version  Tags
+runnable  mosquitto/base         local       -        mqtt, broker, iot, messaging, publish-subscribe, lightweight, ssl, tls, open source
+runnable  mosquitto/mosquitto-broker  local       -        mqtt, broker, iot, messaging, publish-subscribe, lightweight, ssl, tls, open source
+```
+
+## Deploy Stack
+
+```bash
+foo@bar:~$ monk run mosquitto/mosquitto-broker
+✔ Starting the run job: local/mosquitto/mosquitto-broker... DONE
+✔ Preparing nodes DONE
+✔ Checking/pulling images DONE
+✔ Starting containers DONE
+✔ New container 3cecf5dddbe0c8b614e98f2c3a1aae09-local-mosquitto-mosquitto-broker-broker created DONE
+✔ Started local/mosquitto/mosquitto-broker
+🔩 templates/local/mosquitto/mosquitto-broker
+ └─🧊 Peer local
+    └─🔩 templates/local/mosquitto/mosquitto-broker
+       └─📦 3cecf5dddbe0c8b614e98f2c3a1aae09-local-mosquitto-mosquitto-broker-broker running
+          ├─🧩 eclipse-mosquitto:latest
+          └─💾 /var/lib/monkd/volumes/mosquitto -> /mosquitto/data
+
+💡 You can inspect and manage your above stack with these commands:
+        monk logs (-f) local/mosquitto/mosquitto-broker - Inspect logs
+        monk shell     local/mosquitto/mosquitto-broker - Connect to the container's shell
+        monk do        local/mosquitto/mosquitto-broker/action_name - Run defined action (if exists)
+💡 Check monk help for more!
+```
+
+## Access MQTT Broker
+
+The MQTT broker will be available on:
+- **MQTT Port**: 1883
+- **WebSocket Port**: 9001
+
+You can test the connection using any MQTT client like mosquitto_pub/mosquitto_sub:
+
+```bash
+# Subscribe to a topic
+mosquitto_sub -h localhost -p 1883 -t test/topic
+
+# Publish to a topic
+mosquitto_pub -h localhost -p 1883 -t test/topic -m "Hello World"
+```
+
+## Variables
+
+The variables are in `mosquitto.yml` file. You can quickly setup by editing the values here.
+
+| Variable             | Description                    | Default     |
+| -------------------- | ------------------------------ | ----------- |
+| mqtt-port            | MQTT Protocol Port             | 1883        |
+| websocket-port       | WebSocket Port                 | 9001        |
+| allow-anonymous      | Allow anonymous connections    | true        |
+| max-connections      | Maximum connections (-1=unlimited) | -1      |
+| log-level            | Logging level                  | information |
+| persistence          | Enable message persistence     | true        |
+| websocket-enabled    | Enable WebSocket support       | true        |
+| retain-available     | Enable message retention       | true        |
+
+## Stop, remove and clean up workloads and templates
+
+```bash
+monk purge -x -a
+``` 

--- a/mosquitto.yml
+++ b/mosquitto.yml
@@ -1,0 +1,104 @@
+namespace: mosquitto
+
+base:
+  defines: runnable
+  metadata:
+    name: Mosquitto | Open Source MQTT Broker
+    description: |
+      Eclipse Mosquitto is an open source message broker that implements the MQTT protocol versions 5.0, 3.1.1 and 3.1.
+      Mosquitto is lightweight and is suitable for use on all devices from low power single board computers to full servers.
+      The MQTT protocol provides a lightweight method of carrying out messaging using a publish/subscribe model.
+      This makes it suitable for Internet of Things messaging such as with low power sensors or mobile devices such as phones, embedded computers or microcontrollers.
+      Mosquitto features SSL/TLS support, quality of service levels 0, 1 and 2, and both clean and persistent sessions.
+    tags: mqtt, broker, iot, messaging, publish-subscribe, lightweight, ssl, tls, open source
+    website: https://mosquitto.org/
+    publisher: monk.io
+    icon: https://mosquitto.org/images/mosquitto-text-side-28.png
+    source: https://github.com/eclipse/mosquitto
+    private: true
+  containers:
+    broker:
+      image: eclipse-mosquitto
+      image-tag: latest
+
+mosquitto-broker:
+  defines: runnable
+  inherits: mosquitto/base
+  metadata:
+    private: false
+  containers:
+    broker:
+      paths:
+        - <- `${monk-volume-path}/mosquitto/data:/mosquitto/data`
+      ports:
+        - <- `${mqtt-port}:${mqtt-port}`
+        - <- `${websocket-port}:${websocket-port}`
+  files:
+    mosquitto-conf:
+      container: broker
+      mode: 0755
+      path: /mosquitto/config/mosquitto.conf
+      contents: |
+        # Mosquitto Configuration
+        listener {{ v "mqtt-port" }}
+        allow_anonymous {{ v "allow-anonymous" }}
+        
+        # WebSocket listener
+        listener {{ v "websocket-port" }}
+        protocol websockets
+        
+        # Persistence
+        persistence {{ v "persistence" }}
+        persistence_location /mosquitto/data/
+        
+        # Logging
+        log_dest stdout
+        log_type all
+        
+        # Connection limits
+        max_connections {{ v "max-connections" }}
+        
+        # Message retention
+        retain_available {{ v "retain-available" }}
+        
+        # Quality of Service
+        max_queued_messages 1000
+        message_size_limit 0
+  services:
+    mqtt:
+      container: broker
+      protocol: tcp
+      port: <- `${mqtt-port}`
+      host-port: <- `${mqtt-port}`
+      publish: false
+    websocket:
+      container: broker
+      protocol: tcp
+      port: <- `${websocket-port}`
+      host-port: <- `${websocket-port}`
+      publish: false
+  variables:
+    mqtt-port:
+      type: int
+      value: 1883
+    websocket-port:
+      type: int
+      value: 9001
+    allow-anonymous:
+      type: bool
+      value: true
+    max-connections:
+      type: int
+      value: -1
+    log-level:
+      type: string
+      value: information
+    persistence:
+      type: bool
+      value: true
+    websocket-enabled:
+      type: bool
+      value: true
+    retain-available:
+      type: bool
+      value: true


### PR DESCRIPTION
This pull request introduces a Monk.io template for deploying the Mosquitto MQTT Broker, including configuration files, documentation, and deployment instructions. The changes aim to streamline the setup and deployment process for Mosquitto using Monk. Key updates include the addition of a `MANIFEST` file, a detailed `README.md`, and a `mosquitto.yml` configuration file.

### Template and Configuration:

* **`MANIFEST` file**: Added references to the repository (`monk-mosquitto`) and the configuration file (`mosquitto.yml`) to enable loading the template.
* **`mosquitto.yml`**: Introduced a comprehensive Monk configuration file for Mosquitto, defining metadata, container setup, ports, services, and variables for customization. Includes support for MQTT and WebSocket protocols, persistence, logging, and connection limits.

### Documentation:

* **`README.md`**: Updated with detailed instructions for prerequisites, cloning the repository, loading the template, deploying the stack, accessing the MQTT broker, and managing workloads. Includes examples of publishing and subscribing to MQTT topics and a table of configurable variables.